### PR TITLE
A few fixes for the Makefile:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,21 @@
 
 MODULES = pg_hibernate
 
-ifdef USE_PGXS
 PG_CONFIG = pg_config
+
+# Pull out the version number from pg_config
+VERSION := $(shell $(PG_CONFIG) --version | awk '{print $$2}')
+ifeq ("$(VERSION)","")
+$(error pg_config not found)
+endif
+
+# version as a number, e.g. 9.1.4 -> 901
+INTVERSION := $(shell echo $$(($$(echo $(VERSION) | sed 's/\([[:digit:]]\{1,\}\)\.\([[:digit:]]\{1,\}\).*/\1*100+\2/'))))
+
+# We support PostgreSQL 9.3 and later.
+ifeq ($(shell echo $$(($(INTVERSION) < 903))),1)
+$(error pg_hibernate requires PostgreSQL 9.3 or later. This is $(VERSION))
+endif
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
-else
-subdir = contrib/pg_hibernate
-top_builddir = ../..
-include $(top_builddir)/src/Makefile.global
-include $(top_srcdir)/contrib/contrib-global.mk
-endif

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This extension is aimed at reducing the ramp-up time of Postgres servers.
 Compile and install the extension (of course, you'd need Postgres installation or
 source code):
 
-    $ make -C pg_hibernate/ install
+    $ make install
 
 Then.
 


### PR DESCRIPTION
- Lose USE_PGXS, per modern custom
- bail out cleanly on versions of PostgreSQL < 9.3

Some logic adapted from pg_repack's Makefile.
